### PR TITLE
[FEAT] 구글, 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/connectCo/domain/Member/client/GoogleMemberClient.java
+++ b/src/main/java/com/connectCo/domain/Member/client/GoogleMemberClient.java
@@ -1,0 +1,29 @@
+package com.connectCo.domain.Member.client;
+
+import com.connectCo.domain.Member.dto.client.GoogleMemberResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class GoogleMemberClient {
+    private final WebClient webClient;
+
+    public GoogleMemberClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://www.googleapis.com/oauth2/v3/userinfo")
+                .build();
+    }
+
+    public String getGoogleUserId(String accessToken) {
+        GoogleMemberResponse response = webClient
+                .get()
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(GoogleMemberResponse.class)
+                .block();
+        if(response != null) {
+            return response.getSub();
+        }
+        throw new RuntimeException("올바르지 않은 액세스 토큰입니다.");
+    }
+}

--- a/src/main/java/com/connectCo/domain/Member/client/KakaoMemberClient.java
+++ b/src/main/java/com/connectCo/domain/Member/client/KakaoMemberClient.java
@@ -1,0 +1,30 @@
+package com.connectCo.domain.Member.client;
+
+import com.connectCo.domain.Member.dto.client.KakaoMemberResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class KakaoMemberClient {
+
+    private final WebClient webClient;
+
+    public KakaoMemberClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://kapi.kakao.com/v2/user/me")
+                .build();
+    }
+
+    public String getKakaoUserId(String accessToken) {
+        KakaoMemberResponse response = webClient
+                .get()
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(KakaoMemberResponse.class)
+                .block();
+        if(response != null) {
+            return response.getId();
+        }
+        throw new RuntimeException("올바르지 않은 엑세스 토큰입니다.");
+    }
+}

--- a/src/main/java/com/connectCo/domain/Member/controller/MemberController.java
+++ b/src/main/java/com/connectCo/domain/Member/controller/MemberController.java
@@ -21,9 +21,8 @@ public class MemberController {
     }
 
     @PostMapping("/kakao")
-    public MemberLoginResponse saveMemberByKakao() {
-        // TODO 카카오 로그인 구현
-        return null;
+    public MemberLoginResponse saveMemberByKakao(@RequestParam(name = "accessToken") String accessToken) {
+        return memberService.saveMemberByKakao(accessToken);
     }
 
 

--- a/src/main/java/com/connectCo/domain/Member/controller/MemberController.java
+++ b/src/main/java/com/connectCo/domain/Member/controller/MemberController.java
@@ -15,9 +15,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/google")
-    public MemberLoginResponse saveMemberByGoogle() {
-        // TODO 구글 로그인 구현
-        return null;
+    public MemberLoginResponse saveMemberByGoogle(@RequestParam(name = "accessToken") String accessToken) {
+        return memberService.saveMemberByGoogle(accessToken);
     }
 
     @PostMapping("/kakao")

--- a/src/main/java/com/connectCo/domain/Member/dto/client/GoogleMemberResponse.java
+++ b/src/main/java/com/connectCo/domain/Member/dto/client/GoogleMemberResponse.java
@@ -1,0 +1,13 @@
+package com.connectCo.domain.Member.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleMemberResponse {
+    private String sub;
+    private String name;
+}

--- a/src/main/java/com/connectCo/domain/Member/dto/client/KakaoMemberResponse.java
+++ b/src/main/java/com/connectCo/domain/Member/dto/client/KakaoMemberResponse.java
@@ -1,0 +1,18 @@
+package com.connectCo.domain.Member.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoMemberResponse {
+    private String id;
+    private Properties properties;
+
+    @Getter
+    public static class Properties {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/connectCo/domain/Member/dto/response/MemberLoginResponse.java
+++ b/src/main/java/com/connectCo/domain/Member/dto/response/MemberLoginResponse.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MemberLoginResponse {
+public class    MemberLoginResponse {
     private UUID memberId;
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/com/connectCo/domain/Member/entity/Member.java
+++ b/src/main/java/com/connectCo/domain/Member/entity/Member.java
@@ -35,7 +35,6 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
-    @Column(nullable = false)
     private String refreshToken;
 
     @JoinColumn

--- a/src/main/java/com/connectCo/domain/Member/service/MemberService.java
+++ b/src/main/java/com/connectCo/domain/Member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.connectCo.domain.Member.dto.response.MemberLoginResponse;
 
 public interface MemberService {
     MemberLoginResponse saveMemberByNaver(String accessToken);
-
     MemberLoginResponse saveMemberByKakao(String accessToken);
+    MemberLoginResponse saveMemberByGoogle(String accessToken);
+
 }

--- a/src/main/java/com/connectCo/domain/Member/service/MemberService.java
+++ b/src/main/java/com/connectCo/domain/Member/service/MemberService.java
@@ -4,4 +4,6 @@ import com.connectCo.domain.Member.dto.response.MemberLoginResponse;
 
 public interface MemberService {
     MemberLoginResponse saveMemberByNaver(String accessToken);
+
+    MemberLoginResponse saveMemberByKakao(String accessToken);
 }

--- a/src/main/java/com/connectCo/domain/Member/service/MemberServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/Member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.connectCo.domain.Member.service;
 
+import com.connectCo.domain.Member.client.GoogleMemberClient;
 import com.connectCo.domain.Member.client.KakaoMemberClient;
 import com.connectCo.domain.Member.client.NaverMemberClient;
 import com.connectCo.domain.Member.dto.response.MemberLoginResponse;
@@ -24,6 +25,7 @@ public class MemberServiceImpl implements MemberService {
     private final AuthService authService;
     private final NaverMemberClient naverMemberClient;
     private final KakaoMemberClient kakaoMemberClient;
+    private final GoogleMemberClient googleMemberClient;
 
 
     @Override
@@ -41,12 +43,22 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public MemberLoginResponse saveMemberByKakao(String accessToken) {
         String clientId = getKakaoClientId(accessToken);
-        System.out.println("${clientId}" + clientId);
         Optional<Member> member = memberRepository.findByClientIdAndLoginType(clientId, LoginType.KAKAO);
         if(member.isPresent()) {
             return getMemberLoginResponse(member.get());
         }
         return getNewMemberLoginResponse(clientId, LoginType.KAKAO);
+    }
+
+    @Override
+    @Transactional
+    public MemberLoginResponse saveMemberByGoogle(String accessToken) {
+        String clientId = getGoogleClientId(accessToken);
+        Optional<Member> member = memberRepository.findByClientIdAndLoginType(clientId, LoginType.GOOGLE);
+        if(member.isPresent()) {
+            return getMemberLoginResponse(member.get());
+        }
+        return getNewMemberLoginResponse(clientId, LoginType.GOOGLE);
     }
 
     private String getNaverClientId(final String accessToken) {
@@ -55,6 +67,10 @@ public class MemberServiceImpl implements MemberService {
 
     private String getKakaoClientId(final String accessToken) {
         return kakaoMemberClient.getKakaoUserId(accessToken);
+    }
+
+    private String getGoogleClientId(final String accessToken) {
+        return googleMemberClient.getGoogleUserId(accessToken);
     }
 
     private MemberLoginResponse getMemberLoginResponse(final Member member) {

--- a/src/main/java/com/connectCo/domain/Member/service/MemberServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/Member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.connectCo.domain.Member.service;
 
+import com.connectCo.domain.Member.client.KakaoMemberClient;
 import com.connectCo.domain.Member.client.NaverMemberClient;
 import com.connectCo.domain.Member.dto.response.MemberLoginResponse;
 import com.connectCo.domain.Member.entity.LoginType;
@@ -22,6 +23,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberMapper memberMapper;
     private final AuthService authService;
     private final NaverMemberClient naverMemberClient;
+    private final KakaoMemberClient kakaoMemberClient;
 
 
     @Override
@@ -35,8 +37,24 @@ public class MemberServiceImpl implements MemberService {
         return getNewMemberLoginResponse(clientId, LoginType.NAVER);
     }
 
+    @Override
+    @Transactional
+    public MemberLoginResponse saveMemberByKakao(String accessToken) {
+        String clientId = getKakaoClientId(accessToken);
+        System.out.println("${clientId}" + clientId);
+        Optional<Member> member = memberRepository.findByClientIdAndLoginType(clientId, LoginType.KAKAO);
+        if(member.isPresent()) {
+            return getMemberLoginResponse(member.get());
+        }
+        return getNewMemberLoginResponse(clientId, LoginType.KAKAO);
+    }
+
     private String getNaverClientId(final String accessToken) {
         return naverMemberClient.getNaverUserId(accessToken);
+    }
+
+    private String getKakaoClientId(final String accessToken) {
+        return kakaoMemberClient.getKakaoUserId(accessToken);
     }
 
     private MemberLoginResponse getMemberLoginResponse(final Member member) {


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. 구글 로그인 구현
    - url : /members/google/accessToken=?
    - accessToken : 구글 서버에서 발급받는 토큰
2. 카카오 로그인 구현
    - url : /members/kakao/accessToken=?
    - accessToken : 카카오 서버에서 발급받는 토큰


## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
