### PR TITLE
[FEAT] 이벤트 페이지 api 구현

### DIFF
--- a/src/main/java/com/connectCo/domain/event/controller/EventController.java
+++ b/src/main/java/com/connectCo/domain/event/controller/EventController.java
@@ -6,9 +6,7 @@ import com.connectCo.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,6 +17,18 @@ import java.util.List;
 public class EventController {
 
     private final EventService eventService;
+
+    @Operation(summary = "이벤트 검색 API")
+    @GetMapping("/?name=keyword")
+    public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByName(@RequestParam String name) {
+        return BaseResponse.onSuccess(eventService.inquiryEventByName(name));
+    }
+    @Operation(summary = "이벤트 세부사항 조회 API")
+    @GetMapping("/{event-id}")
+    public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByEventId (@PathVariable("event-id") String eventId) {
+        return BaseResponse.onSuccess(eventService.inquiryEventByEventId(eventId));
+    }
+
 
     @Operation(summary = "나의 이벤트 조회 API")
     @GetMapping("/mine")

--- a/src/main/java/com/connectCo/domain/event/controller/EventController.java
+++ b/src/main/java/com/connectCo/domain/event/controller/EventController.java
@@ -26,7 +26,7 @@ public class EventController {
 
 
     @Operation(summary = "이벤트 생성 API")
-    @PostMapping("/")
+    @PostMapping("")
     public BaseResponse<EventIdResponse> createEvent (@RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages, @RequestBody EventCreateRequest request){
         return BaseResponse.onSuccess(eventService.createEvent(eventImages, request));
     }
@@ -45,8 +45,8 @@ public class EventController {
 
     @Operation(summary = "이벤트 검색 API")
     @GetMapping("")
-    public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByName(@RequestParam String name) {
-        return BaseResponse.onSuccess(eventService.inquiryEventByName(name));
+    public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByName(@RequestParam String keyword) {
+        return BaseResponse.onSuccess(eventService.inquiryEventByKeyword(keyword));
     }
 
     @Operation(summary = "이벤트 세부사항 조회 API")
@@ -62,15 +62,10 @@ public class EventController {
     }
 
     @Operation(summary = "이벤트 찜하기 API")
-    @PostMapping("/{eventId}/likes")
+    @PostMapping("/{eventId}/like")
     public BaseResponse<EventLikeResponse> likeEvent(@PathVariable("eventId") UUID eventId){
         return BaseResponse.onSuccess(eventService.likeEvent(eventId));
     }
-
-    //Operation(summary = "이벤트 추천 조회 API")
-
-
-
 
 
     @Operation(summary = "나의 이벤트 조회 API")

--- a/src/main/java/com/connectCo/domain/event/controller/EventController.java
+++ b/src/main/java/com/connectCo/domain/event/controller/EventController.java
@@ -1,5 +1,9 @@
 package com.connectCo.domain.event.controller;
 
+import com.connectCo.domain.event.dto.request.EventCreateRequest;
+import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
+import com.connectCo.domain.event.dto.response.EventIdResponse;
+import com.connectCo.domain.event.dto.response.EventLikeResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
 import com.connectCo.domain.event.service.EventService;
 import com.connectCo.global.common.BaseResponse;
@@ -7,8 +11,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "이벤트 API", description = "이벤트 관련 API")
 @RestController
@@ -18,16 +24,53 @@ public class EventController {
 
     private final EventService eventService;
 
+
+    @Operation(summary = "이벤트 생성 API")
+    @PostMapping("/")
+    public BaseResponse<EventIdResponse> createEvent (@RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages, @RequestBody EventCreateRequest request){
+        return BaseResponse.onSuccess(eventService.createEvent(eventImages, request));
+    }
+
+    @Operation(summary = "이벤트 수정 API")
+    @PutMapping("/{eventId}")
+    public BaseResponse <EventSummaryInquiryResponse> updateEvent (@PathVariable UUID eventId, @RequestBody EventCreateRequest request, @RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages){
+        return BaseResponse.onSuccess(eventService.updateEvent(eventId, request, eventImages));
+    }
+
+    @Operation(summary = "이벤트 삭제 API")
+    @DeleteMapping("/{eventId}")
+    public BaseResponse<UUID> deleteEvent(@PathVariable UUID eventId){
+        return BaseResponse.onSuccess(eventService.deleteEvent(eventId));
+    }
+
     @Operation(summary = "이벤트 검색 API")
-    @GetMapping("/?name=keyword")
+    @GetMapping("")
     public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByName(@RequestParam String name) {
         return BaseResponse.onSuccess(eventService.inquiryEventByName(name));
     }
+
     @Operation(summary = "이벤트 세부사항 조회 API")
-    @GetMapping("/{event-id}")
-    public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByEventId (@PathVariable("event-id") String eventId) {
-        return BaseResponse.onSuccess(eventService.inquiryEventByEventId(eventId));
+    @GetMapping("/{eventId}")
+    public BaseResponse<EventDetailInquiryResponse> inquiryEventByEventId (@PathVariable("eventId") UUID eventId) {
+        return BaseResponse.onSuccess(eventService.inquiryEventDetailByEventId(eventId));
     }
+
+    @Operation(summary = "이벤트 최신순 조회 API")
+    @GetMapping("/recent")
+    public BaseResponse<List<EventSummaryInquiryResponse>> inquiryEventByCreatedAt(){
+        return BaseResponse.onSuccess(eventService.inquiryEventByRecent());
+    }
+
+    @Operation(summary = "이벤트 찜하기 API")
+    @PostMapping("/{eventId}/likes")
+    public BaseResponse<EventLikeResponse> likeEvent(@PathVariable("eventId") UUID eventId){
+        return BaseResponse.onSuccess(eventService.likeEvent(eventId));
+    }
+
+    //Operation(summary = "이벤트 추천 조회 API")
+
+
+
 
 
     @Operation(summary = "나의 이벤트 조회 API")

--- a/src/main/java/com/connectCo/domain/event/controller/EventController.java
+++ b/src/main/java/com/connectCo/domain/event/controller/EventController.java
@@ -27,13 +27,18 @@ public class EventController {
 
     @Operation(summary = "이벤트 생성 API")
     @PostMapping("")
-    public BaseResponse<EventIdResponse> createEvent (@RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages, @RequestBody EventCreateRequest request){
+    public BaseResponse<EventIdResponse> createEvent (
+            @RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages,
+            @RequestPart EventCreateRequest request){
         return BaseResponse.onSuccess(eventService.createEvent(eventImages, request));
     }
 
     @Operation(summary = "이벤트 수정 API")
     @PutMapping("/{eventId}")
-    public BaseResponse <EventSummaryInquiryResponse> updateEvent (@PathVariable UUID eventId, @RequestBody EventCreateRequest request, @RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages){
+    public BaseResponse <EventSummaryInquiryResponse> updateEvent (
+            @PathVariable UUID eventId,
+            @RequestPart EventCreateRequest request,
+            @RequestPart(value = "eventImages", required = false) List<MultipartFile> eventImages){
         return BaseResponse.onSuccess(eventService.updateEvent(eventId, request, eventImages));
     }
 

--- a/src/main/java/com/connectCo/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/connectCo/domain/event/dto/request/EventCreateRequest.java
@@ -1,0 +1,23 @@
+package com.connectCo.domain.event.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventCreateRequest {
+    private String organizationName;
+    private String name;
+    private String description;
+    private String priorityTarget;
+    private String benefitTarget;
+    private String notification;
+    private LocalDate expiredAt;
+    private String thumbnail;
+}
+
+

--- a/src/main/java/com/connectCo/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/connectCo/domain/event/dto/request/EventCreateRequest.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstrguctor
+@NoArgsConstructor
 public class EventCreateRequest {
     private String organizationName;
     private String address;

--- a/src/main/java/com/connectCo/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/connectCo/domain/event/dto/request/EventCreateRequest.java
@@ -8,9 +8,10 @@ import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstrguctor
 public class EventCreateRequest {
     private String organizationName;
+    private String address;
     private String name;
     private String description;
     private String priorityTarget;

--- a/src/main/java/com/connectCo/domain/event/dto/response/EventDetailInquiryResponse.java
+++ b/src/main/java/com/connectCo/domain/event/dto/response/EventDetailInquiryResponse.java
@@ -1,0 +1,23 @@
+package com.connectCo.domain.event.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class EventDetailInquiryResponse {
+    private UUID eventId;
+    private String organizationName;
+    private String name;
+    private String description;
+    private String priorityTarget;
+    private String benefitTarget;
+    private String notification;
+    private LocalDate expiredAt;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    private String thumbnail;
+}

--- a/src/main/java/com/connectCo/domain/event/dto/response/EventIdResponse.java
+++ b/src/main/java/com/connectCo/domain/event/dto/response/EventIdResponse.java
@@ -1,0 +1,12 @@
+package com.connectCo.domain.event.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class EventIdResponse {
+    private UUID eventId;
+}

--- a/src/main/java/com/connectCo/domain/event/dto/response/EventLikeResponse.java
+++ b/src/main/java/com/connectCo/domain/event/dto/response/EventLikeResponse.java
@@ -1,0 +1,13 @@
+package com.connectCo.domain.event.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class EventLikeResponse {
+    private UUID eventId;
+    private UUID memberId;
+}

--- a/src/main/java/com/connectCo/domain/event/dto/response/EventSummaryInquiryResponse.java
+++ b/src/main/java/com/connectCo/domain/event/dto/response/EventSummaryInquiryResponse.java
@@ -15,4 +15,5 @@ public class EventSummaryInquiryResponse {
     private LocalDate startAt;
     private LocalDate endAt;
     private String thumbnail;
+
 }

--- a/src/main/java/com/connectCo/domain/event/dto/response/EventUpdateReponse.java
+++ b/src/main/java/com/connectCo/domain/event/dto/response/EventUpdateReponse.java
@@ -1,0 +1,14 @@
+package com.connectCo.domain.event.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EventUpdateReponse {
+    Long BookMarkId;
+    LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/connectCo/domain/event/entity/Event.java
+++ b/src/main/java/com/connectCo/domain/event/entity/Event.java
@@ -53,6 +53,10 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private String priorityTarget;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer likeCount=0;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
     private Member member;
@@ -66,4 +70,29 @@ public class Event extends BaseEntity {
 
     @OneToMany(mappedBy = "event")
     private List<EventImage> images;
+
+    public void changeImages(List<EventImage> eventImages) {
+        // 기존 이미지가 있다면 삭제
+        if(this.images != null) removeImages();
+
+        // 새로운 이미지로 변경
+        this.images = eventImages;
+    }
+
+    private void removeImages() {
+        this.images.forEach(BaseEntity::delete);
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/connectCo/domain/event/entity/EventLike.java
+++ b/src/main/java/com/connectCo/domain/event/entity/EventLike.java
@@ -33,4 +33,9 @@ public class EventLike extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
     private Event event;
+
+    public void changeIsChecked(){
+        this.isChecked = !this.isChecked;
+    }
+
 }

--- a/src/main/java/com/connectCo/domain/event/mapper/EventLikeMapper.java
+++ b/src/main/java/com/connectCo/domain/event/mapper/EventLikeMapper.java
@@ -1,0 +1,26 @@
+package com.connectCo.domain.event.mapper;
+
+import com.connectCo.domain.Member.entity.Member;
+import com.connectCo.domain.event.dto.response.EventLikeResponse;
+import com.connectCo.domain.event.entity.Event;
+import com.connectCo.domain.event.entity.EventLike;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventLikeMapper {
+
+    public EventLike toEventLike(Member member, Event event){
+        return EventLike.builder()
+                .member(member)
+                .isChecked(true)
+                .event(event)
+                .build();
+    }
+
+    public EventLikeResponse toEventLikeResponse(Member member, Event event){
+        return EventLikeResponse.builder()
+                .memberId(member.getId())
+                .eventId(event.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/connectCo/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/connectCo/domain/event/mapper/EventMapper.java
@@ -1,5 +1,6 @@
 package com.connectCo.domain.event.mapper;
 
+import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
 import com.connectCo.domain.event.entity.Event;
 import com.connectCo.domain.event.entity.EventImage;
@@ -10,6 +11,32 @@ import java.util.Optional;
 
 @Component
 public class EventMapper {
+
+    public EventDetailInquiryResponse toEventDetailInquiryResponse(Event event){
+        String organizationName = Optional.ofNullable(event.getOrganization())
+                .map(Organization::getName)
+                .orElse(null);
+
+        String thumbnail = event.getImages().stream()
+                .findFirst()
+                .map(EventImage::getUrl)
+                .orElse(null);
+
+        return EventDetailInquiryResponse.builder()
+                .eventId(event.getId())
+                .organizationName(organizationName)
+                .name(event.getName())
+                .description(event.getDescription())
+                .priorityTarget(event.getPriorityTarget())
+                .benefitTarget(event.getBenefitTarget())
+                .notification(event.getNotification())
+                .expiredAt(event.getExpiredAt())
+                .startAt(event.getStartAt())
+                .endAt(event.getEndAt())
+                .thumbnail(thumbnail)
+                .build();
+    }
+
 
     public EventSummaryInquiryResponse toEventSummaryInquiryResponse(Event event) {
         String organizationName = Optional.ofNullable(event.getOrganization())

--- a/src/main/java/com/connectCo/domain/event/mapper/EventMapper.java
+++ b/src/main/java/com/connectCo/domain/event/mapper/EventMapper.java
@@ -1,5 +1,7 @@
 package com.connectCo.domain.event.mapper;
 
+import com.connectCo.domain.Member.entity.Member;
+import com.connectCo.domain.event.dto.request.EventCreateRequest;
 import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
 import com.connectCo.domain.event.entity.Event;
@@ -11,6 +13,25 @@ import java.util.Optional;
 
 @Component
 public class EventMapper {
+
+    public Event toEvent(Member member, EventCreateRequest request){
+        return Event.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .priorityTarget(request.getPriorityTarget())
+                .benefitTarget(request.getBenefitTarget())
+                .notification(request.getNotification())
+                .expiredAt(request.getExpiredAt())
+                .member(member)
+                .build();
+    }
+
+    public EventImage toEventImage(Event event, String url) {
+        return EventImage.builder()
+                .event(event)
+                .url(url)
+                .build();
+    }
 
     public EventDetailInquiryResponse toEventDetailInquiryResponse(Event event){
         String organizationName = Optional.ofNullable(event.getOrganization())

--- a/src/main/java/com/connectCo/domain/event/repository/EventImageRepository.java
+++ b/src/main/java/com/connectCo/domain/event/repository/EventImageRepository.java
@@ -1,0 +1,9 @@
+package com.connectCo.domain.event.repository;
+
+import com.connectCo.domain.event.entity.EventImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EventImageRepository extends JpaRepository<EventImage, UUID> {
+}

--- a/src/main/java/com/connectCo/domain/event/repository/EventLikeRepository.java
+++ b/src/main/java/com/connectCo/domain/event/repository/EventLikeRepository.java
@@ -1,12 +1,16 @@
 package com.connectCo.domain.event.repository;
 
 import com.connectCo.domain.Member.entity.Member;
+import com.connectCo.domain.event.entity.Event;
 import com.connectCo.domain.event.entity.EventLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, UUID> {
     List<EventLike> findAllByMemberAndIsChecked(Member member, boolean isChecked);
+
+    Optional<EventLike> findAllByMemberAndEvent(Member member, Event event);
 }

--- a/src/main/java/com/connectCo/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/connectCo/domain/event/repository/EventRepository.java
@@ -2,19 +2,24 @@ package com.connectCo.domain.event.repository;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.event.entity.Event;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event, UUID> {
 
     List<Event> findAllByMember(Member member);
-    List<Event> findAllByName(String Name);
-    Optional<Event> findById(String eventId);
 
-    Page<Event> findAll(Pageable pageable);
+    @Query("SELECT DISTINCT e FROM Event e JOIN e.organization o WHERE (e.name LIKE%:keyword% OR o.name LIKE%:keyword%) AND e.expiredAt >= :currentTime")
+    List<Event> findAllBySearch(String Name, @Param("currentTime")LocalDateTime currentTime);
+    List<Event> findAllByOrderByCreatedAtDesc();
+
+    @Query("SELECT DISTINCT e FROM Event e  WHERE e.expiredAt >= :currentTime GROUP BY e ORDER BY e.likeCount DESC")
+    List<Event> findAllByRecommends(@Param("currentTime")LocalDateTime currentTime);
+
+    //Event findById(UUID eventId);
 }

--- a/src/main/java/com/connectCo/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/connectCo/domain/event/repository/EventRepository.java
@@ -2,12 +2,19 @@ package com.connectCo.domain.event.repository;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.event.entity.Event;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event, UUID> {
 
     List<Event> findAllByMember(Member member);
+    List<Event> findAllByName(String Name);
+    Optional<Event> findById(String eventId);
+
+    Page<Event> findAll(Pageable pageable);
 }

--- a/src/main/java/com/connectCo/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/connectCo/domain/event/repository/EventRepository.java
@@ -15,7 +15,7 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     List<Event> findAllByMember(Member member);
 
     @Query("SELECT DISTINCT e FROM Event e JOIN e.organization o WHERE (e.name LIKE%:keyword% OR o.name LIKE%:keyword%) AND e.expiredAt >= :currentTime")
-    List<Event> findAllBySearch(String Name, @Param("currentTime")LocalDateTime currentTime);
+    List<Event> findAllBySearch(String keyword, @Param("currentTime")LocalDateTime currentTime);
     List<Event> findAllByOrderByCreatedAtDesc();
 
     @Query("SELECT DISTINCT e FROM Event e  WHERE e.expiredAt >= :currentTime GROUP BY e ORDER BY e.likeCount DESC")

--- a/src/main/java/com/connectCo/domain/event/service/EventService.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventService.java
@@ -22,7 +22,7 @@ public interface EventService {
     EventLikeResponse likeEvent(UUID eventId);
     List<EventSummaryInquiryResponse> inquiryEventByRecent();
     List<EventSummaryInquiryResponse> inquiryEventByRecommends();
-    List<EventSummaryInquiryResponse> inquiryEventByName(String name);
+    List<EventSummaryInquiryResponse> inquiryEventByKeyword(String keyword);
     List<EventSummaryInquiryResponse> inquiryEventByMember();
     List<EventSummaryInquiryResponse> inquiryEventByLike();
 

--- a/src/main/java/com/connectCo/domain/event/service/EventService.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventService.java
@@ -1,17 +1,30 @@
 package com.connectCo.domain.event.service;
 
+import com.connectCo.domain.event.dto.request.EventCreateRequest;
 import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
+import com.connectCo.domain.event.dto.response.EventIdResponse;
+import com.connectCo.domain.event.dto.response.EventLikeResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface EventService {
 
-    UUID getEventId(String eventId);
-    //Page<EventDetailInquiryResponse> inquiryEventByStartedAt();
-    EventDetailInquiryResponse inquiryEventByEventId(String eventId);
+    EventIdResponse createEvent(List<MultipartFile> eventImages, EventCreateRequest request);
+
+
+    EventSummaryInquiryResponse updateEvent(UUID eventId, EventCreateRequest request, List<MultipartFile> eventImages);
+    EventDetailInquiryResponse inquiryEventDetailByEventId(UUID eventId);
+    UUID deleteEvent(UUID eventId);
+
+    EventLikeResponse likeEvent(UUID eventId);
+    List<EventSummaryInquiryResponse> inquiryEventByRecent();
+    List<EventSummaryInquiryResponse> inquiryEventByRecommends();
     List<EventSummaryInquiryResponse> inquiryEventByName(String name);
     List<EventSummaryInquiryResponse> inquiryEventByMember();
     List<EventSummaryInquiryResponse> inquiryEventByLike();
+
+
 }

--- a/src/main/java/com/connectCo/domain/event/service/EventService.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventService.java
@@ -1,11 +1,17 @@
 package com.connectCo.domain.event.service;
 
+import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface EventService {
 
+    UUID getEventId(String eventId);
+    //Page<EventDetailInquiryResponse> inquiryEventByStartedAt();
+    EventDetailInquiryResponse inquiryEventByEventId(String eventId);
+    List<EventSummaryInquiryResponse> inquiryEventByName(String name);
     List<EventSummaryInquiryResponse> inquiryEventByMember();
     List<EventSummaryInquiryResponse> inquiryEventByLike();
 }

--- a/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
@@ -20,6 +20,7 @@ import com.connectCo.global.exception.ErrorCode;
 import com.connectCo.utils.S3FileComponent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -40,6 +41,7 @@ public class EventServiceImpl implements EventService{
     private final S3FileComponent s3FileComponent;
 
     @Override// 이벤트 생성
+    @Transactional
     public EventIdResponse createEvent(List<MultipartFile> eventImages, EventCreateRequest request){
         Member member = authService.getLoginMember();
 
@@ -53,6 +55,7 @@ public class EventServiceImpl implements EventService{
     }
 
     @Override// 이벤트 수정
+    @Transactional
     public EventSummaryInquiryResponse updateEvent(UUID eventId, EventCreateRequest request, List<MultipartFile> eventImages){
 
         Event existingEvent = eventRepository.findById(eventId).orElseThrow(() -> new CustomApiException(ErrorCode.EVENT_NOT_FOUND));
@@ -65,6 +68,7 @@ public class EventServiceImpl implements EventService{
         return eventMapper.toEventSummaryInquiryResponse(eventRepository.save(existingEvent));
     }
     @Override//이벤트 삭제
+    @Transactional
     public UUID deleteEvent(UUID eventId){
         Member member = authService.getLoginMember();
 
@@ -79,6 +83,7 @@ public class EventServiceImpl implements EventService{
         return deletedEventId;
     }
     @Override//이벤트 검색하기 우선 학교 이름과 이벤트 제목 둘다에서 검색 되게 해놨습니다.
+    @Transactional
     public List<EventSummaryInquiryResponse> inquiryEventByKeyword(String keyword){
         LocalDateTime currentTime = LocalDateTime.now();
         List<Event> eventList = eventRepository.findAllBySearch(keyword, currentTime);
@@ -88,6 +93,7 @@ public class EventServiceImpl implements EventService{
     }
 
     @Override//이벤트 최신순 조회하기
+    @Transactional
     public List<EventSummaryInquiryResponse> inquiryEventByRecent(){
         List<Event> eventList = eventRepository.findAllByOrderByCreatedAtDesc();
 
@@ -96,6 +102,7 @@ public class EventServiceImpl implements EventService{
                 .toList();
     }
     @Override
+    @Transactional
     public List<EventSummaryInquiryResponse> inquiryEventByRecommends(){
         LocalDateTime currentTime = LocalDateTime.now();
         List<Event> eventList = eventRepository.findAllByRecommends(currentTime);
@@ -105,7 +112,8 @@ public class EventServiceImpl implements EventService{
                 .toList();
     }
 
-    @Override//이벤트 상세 조회하기
+    @Override//이벤트 상세
+    @Transactional
     public EventDetailInquiryResponse inquiryEventDetailByEventId(UUID eventId){
         Optional<Event> event = eventRepository.findById(eventId);
         return event
@@ -114,6 +122,7 @@ public class EventServiceImpl implements EventService{
     }
 
     @Override
+    @Transactional
     public EventLikeResponse likeEvent(UUID eventId){
         Member member = authService.getLoginMember();
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomApiException(ErrorCode.EVENT_NOT_FOUND));

--- a/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
@@ -79,9 +79,9 @@ public class EventServiceImpl implements EventService{
         return deletedEventId;
     }
     @Override//이벤트 검색하기 우선 학교 이름과 이벤트 제목 둘다에서 검색 되게 해놨습니다.
-    public List<EventSummaryInquiryResponse> inquiryEventByName(String name){
+    public List<EventSummaryInquiryResponse> inquiryEventByKeyword(String keyword){
         LocalDateTime currentTime = LocalDateTime.now();
-        List<Event> eventList = eventRepository.findAllBySearch(name, currentTime);
+        List<Event> eventList = eventRepository.findAllBySearch(keyword, currentTime);
         return eventList.stream()
                 .map(eventMapper::toEventSummaryInquiryResponse)
                 .toList();

--- a/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
@@ -2,6 +2,7 @@ package com.connectCo.domain.event.service;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.Member.service.AuthService;
+import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
 import com.connectCo.domain.event.entity.Event;
 import com.connectCo.domain.event.entity.EventLike;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +24,37 @@ public class EventServiceImpl implements EventService{
     private final EventLikeRepository eventLikeRepository;
     private final EventRepository eventRepository;
     private final EventMapper eventMapper;
+
+    @Override
+    public UUID getEventId(String eventId) {
+        return UUID.fromString(eventId);
+    }
+    //@Override
+    //public Page<EventDetailInquiryResponse> inquiryEventByStartedAt(Pageable pageable) {
+    //    Page<Event> eventPage = eventRepository.findAll(pageable);
+
+    //    return eventPage.map(eventMapper::toEventDetailInquiryResponse);
+    //}
+
+    @Override
+    public List<EventSummaryInquiryResponse> inquiryEventByName(String name){
+        // name 이 부분 일치만 해도 검색되게 로직 추가하기
+
+        List<Event> eventList = eventRepository.findAllByName(name);
+        return eventList.stream()
+                .map(eventMapper::toEventSummaryInquiryResponse)
+                .toList();
+    }
+    @Override
+    public EventDetailInquiryResponse inquiryEventByEventId(String eventId){
+        UUID eventUuid =getEventId(eventId);
+        Optional<Event> optionalEvent = eventRepository.findById(eventUuid);
+
+        return optionalEvent
+                .map(eventMapper::toEventDetailInquiryResponse)
+                .orElse(null);
+    }
+
     @Override
     public List<EventSummaryInquiryResponse> inquiryEventByMember() {
 

--- a/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/event/service/EventServiceImpl.java
@@ -2,16 +2,27 @@ package com.connectCo.domain.event.service;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.Member.service.AuthService;
+import com.connectCo.domain.event.dto.request.EventCreateRequest;
 import com.connectCo.domain.event.dto.response.EventDetailInquiryResponse;
+import com.connectCo.domain.event.dto.response.EventIdResponse;
+import com.connectCo.domain.event.dto.response.EventLikeResponse;
 import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
 import com.connectCo.domain.event.entity.Event;
+import com.connectCo.domain.event.entity.EventImage;
 import com.connectCo.domain.event.entity.EventLike;
+import com.connectCo.domain.event.mapper.EventLikeMapper;
 import com.connectCo.domain.event.mapper.EventMapper;
+import com.connectCo.domain.event.repository.EventImageRepository;
 import com.connectCo.domain.event.repository.EventLikeRepository;
 import com.connectCo.domain.event.repository.EventRepository;
+import com.connectCo.global.exception.CustomApiException;
+import com.connectCo.global.exception.ErrorCode;
+import com.connectCo.utils.S3FileComponent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,37 +34,109 @@ public class EventServiceImpl implements EventService{
     private final AuthService authService;
     private final EventLikeRepository eventLikeRepository;
     private final EventRepository eventRepository;
+    private final EventImageRepository eventImageRepository;
     private final EventMapper eventMapper;
+    private final EventLikeMapper eventLikeMapper;
+    private final S3FileComponent s3FileComponent;
 
-    @Override
-    public UUID getEventId(String eventId) {
-        return UUID.fromString(eventId);
+    @Override// 이벤트 생성
+    public EventIdResponse createEvent(List<MultipartFile> eventImages, EventCreateRequest request){
+        Member member = authService.getLoginMember();
+
+        Event newEvent = createAndSaveEvent(member, request);
+
+        List<EventImage> newEventImages = createAndSaveEventImages(newEvent, eventImages);
+
+        newEvent.changeImages(newEventImages);
+
+        return new EventIdResponse(newEvent.getId());
     }
-    //@Override
-    //public Page<EventDetailInquiryResponse> inquiryEventByStartedAt(Pageable pageable) {
-    //    Page<Event> eventPage = eventRepository.findAll(pageable);
 
-    //    return eventPage.map(eventMapper::toEventDetailInquiryResponse);
-    //}
+    @Override// 이벤트 수정
+    public EventSummaryInquiryResponse updateEvent(UUID eventId, EventCreateRequest request, List<MultipartFile> eventImages){
 
-    @Override
+        Event existingEvent = eventRepository.findById(eventId).orElseThrow(() -> new CustomApiException(ErrorCode.EVENT_NOT_FOUND));
+
+        List<EventImage> updateEventImages = updateAndSaveEventImages(existingEvent, eventImages);
+
+        existingEvent.changeImages(updateEventImages);
+
+
+        return eventMapper.toEventSummaryInquiryResponse(eventRepository.save(existingEvent));
+    }
+    @Override//이벤트 삭제
+    public UUID deleteEvent(UUID eventId){
+        Member member = authService.getLoginMember();
+
+        Event event= eventRepository.findById(eventId).orElseThrow(() -> new CustomApiException(ErrorCode.EVENT_NOT_FOUND));
+
+        if(!event.getMember().equals(member)){
+            throw new CustomApiException(ErrorCode.INVALID_PERMISSION);
+        }
+
+        UUID deletedEventId = event.getId();
+        eventRepository.deleteById(deletedEventId);
+        return deletedEventId;
+    }
+    @Override//이벤트 검색하기 우선 학교 이름과 이벤트 제목 둘다에서 검색 되게 해놨습니다.
     public List<EventSummaryInquiryResponse> inquiryEventByName(String name){
-        // name 이 부분 일치만 해도 검색되게 로직 추가하기
+        LocalDateTime currentTime = LocalDateTime.now();
+        List<Event> eventList = eventRepository.findAllBySearch(name, currentTime);
+        return eventList.stream()
+                .map(eventMapper::toEventSummaryInquiryResponse)
+                .toList();
+    }
 
-        List<Event> eventList = eventRepository.findAllByName(name);
+    @Override//이벤트 최신순 조회하기
+    public List<EventSummaryInquiryResponse> inquiryEventByRecent(){
+        List<Event> eventList = eventRepository.findAllByOrderByCreatedAtDesc();
+
         return eventList.stream()
                 .map(eventMapper::toEventSummaryInquiryResponse)
                 .toList();
     }
     @Override
-    public EventDetailInquiryResponse inquiryEventByEventId(String eventId){
-        UUID eventUuid =getEventId(eventId);
-        Optional<Event> optionalEvent = eventRepository.findById(eventUuid);
+    public List<EventSummaryInquiryResponse> inquiryEventByRecommends(){
+        LocalDateTime currentTime = LocalDateTime.now();
+        List<Event> eventList = eventRepository.findAllByRecommends(currentTime);
 
-        return optionalEvent
-                .map(eventMapper::toEventDetailInquiryResponse)
-                .orElse(null);
+        return eventList.stream()
+                .map(eventMapper::toEventSummaryInquiryResponse)
+                .toList();
     }
+
+    @Override//이벤트 상세 조회하기
+    public EventDetailInquiryResponse inquiryEventDetailByEventId(UUID eventId){
+        Optional<Event> event = eventRepository.findById(eventId);
+        return event
+                .map(eventMapper::toEventDetailInquiryResponse)
+                .orElseThrow(null);
+    }
+
+    @Override
+    public EventLikeResponse likeEvent(UUID eventId){
+        Member member = authService.getLoginMember();
+        Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomApiException(ErrorCode.EVENT_NOT_FOUND));
+
+        Optional <EventLike> existingLike = eventLikeRepository.findAllByMemberAndEvent(member, event);
+
+        if(existingLike.isPresent()) // 이미 좋아요 누른 상태라면 좋아요 취소
+        {
+            EventLike eventLike = existingLike.get();
+            event.decreaseLikeCount();
+            eventLike.changeIsChecked();
+            eventLikeRepository.save(eventLike);
+        }
+        else// 좋아요 누른 적이 없으면 좋아요 증가
+        {
+            event.increaseLikeCount();
+            EventLike newEventLike = eventLikeMapper.toEventLike(member, event);
+            eventLikeRepository.save(newEventLike);
+        }
+
+        return eventLikeMapper.toEventLikeResponse(member, event);
+    }
+
 
     @Override
     public List<EventSummaryInquiryResponse> inquiryEventByMember() {
@@ -78,6 +161,28 @@ public class EventServiceImpl implements EventService{
 
         return eventList.stream()
                 .map(eventMapper::toEventSummaryInquiryResponse)
+                .toList();
+    }
+
+    private Event createAndSaveEvent(Member member, EventCreateRequest request) {
+        Event event = eventMapper.toEvent(member, request);
+        return eventRepository.save(event);
+    }
+
+
+    private List<EventImage> createAndSaveEventImages(Event newEvent, List<MultipartFile> eventImages) {
+        return eventImages.stream()
+                .map(eventImage -> s3FileComponent.uploadFile("event", eventImage))
+                .map(eventUrl -> eventMapper.toEventImage(newEvent, eventUrl))
+                .map(eventImageRepository::save)
+                .toList();
+    }
+
+    private List<EventImage> updateAndSaveEventImages(Event updateEvent, List<MultipartFile> eventImages) {
+        return eventImages.stream()
+                .map(eventImage -> s3FileComponent.uploadFile("event", eventImage))
+                .map(eventUrl -> eventMapper.toEventImage(updateEvent, eventUrl))
+                .map(eventImageRepository::save)
                 .toList();
     }
 }

--- a/src/main/java/com/connectCo/global/common/BaseEntity.java
+++ b/src/main/java/com/connectCo/global/common/BaseEntity.java
@@ -20,6 +20,10 @@ public abstract class BaseEntity {
 
     private LocalDateTime deletedAt;
 
+
+    public void update() {
+        this.updatedAt = LocalDateTime.now();
+    }
     public void delete() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/connectCo/global/exception/ErrorCode.java
+++ b/src/main/java/com/connectCo/global/exception/ErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode {
+public enum  ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
@@ -23,6 +23,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER401", "사용자를 찾을 수 없습니다."),
     DUPLICATED_USER_NAME(HttpStatus.CONFLICT, "MEMBER402", "이미 존재하는 사용자입니다."),
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "MEMBER403", "권한이 존재하지 않습니다."),
+
+    //Event
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT401", "이벤트를 찾을 수 업습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
1. 이벤트 생성/수정/삭제 api
2. 추천 이벤트 조회,  최신(모든) 이벤트 조회 api
3. 이벤트 검색 api
4. 이벤트 상세 조회 api
5. 이벤트 찜하기 api

추천 이벤트 조회는 우선 좋아요 수가 많은 순으로 해놨는데 내 생각에 주변 이벤트 중에서 좋아요, 조회 수 많은 순으로 하는게 좋을거 같은데 다같이 얘기해보고 수정할게


+궁금한점
검색 기능을 jpql을 사용해서 구현했는데 검색은 보통 쿼리 dsl을 많이 사용하고 좋은 방식이라고 들어서 수정하는게 좋을지?