### PR TITLE
[REFACTOR] Coupon API 리팩토링

### DIFF
--- a/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
@@ -9,6 +9,7 @@ import com.connectCo.domain.coupon.service.CouponService;
 import com.connectCo.domain.store.entity.Store;
 import com.connectCo.domain.store.service.StoreService;
 import com.connectCo.global.common.BaseResponse;
+import com.connectCo.global.common.enums.InquiryType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -56,15 +57,14 @@ public class CouponController {
         return BaseResponse.onSuccess(couponService.inquiryCouponByLike(page, size));
     }
 
-    @Operation(summary = "쿠폰 조회 API(최신순)")
-    @GetMapping("/recent")
-    public BaseResponse<List<CouponSummaryInquiryResponse>> inquiryCouponByRecent() {
-        return BaseResponse.onSuccess(couponService.inquiryCouponByRecent());
-    }
-    @Operation(summary = "특정 가게의 쿠폰 조회 API")
-    @GetMapping("/store/{storeId}")
-    public BaseResponse<List<CouponSummaryInquiryResponse>> inquiryCouponByEachStore(@PathVariable Long storeId) {
-        return BaseResponse.onSuccess(couponService.inquiryCouponByEachStore(storeId));
+    @Operation(summary = "쿠폰 조회 API(추천순, 거리순, 최근순)")
+    @GetMapping("/recommend")
+    public BaseResponse<CouponPagingResponse<CouponSummaryInquiryResponse>> inquiryCoupon(
+            @RequestParam(name = "type") InquiryType type,
+            @RequestParam(name = "page") int page,
+            @RequestParam(name = "size") int size
+    ){
+        return BaseResponse.onSuccess(couponService.inquiryCoupon(type, page , size));
     }
 
     @Operation(summary = "쿠폰 상세 조회 API")

--- a/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
@@ -45,8 +45,15 @@ public class CouponController {
 
     @Operation(summary = "내가 찜한 쿠폰 조회 API")
     @GetMapping("/like")
-    public BaseResponse<List<CouponSummaryInquiryResponse>> inquiryCouponByLike() {
-        return BaseResponse.onSuccess(couponService.inquiryCouponByLike());
+    @Parameters(value = {
+            @Parameter(name = "page", description = "페이지 번호(0부터 시작)"),
+            @Parameter(name = "size", description = "한 페이지 당 쿠폰 개수"),
+    })
+    public BaseResponse<CouponPagingResponse<CouponSummaryInquiryResponse>> inquiryCouponByLike(
+            @RequestParam(name = "page") int page,
+            @RequestParam(name = "size") int size
+    ) {
+        return BaseResponse.onSuccess(couponService.inquiryCouponByLike(page, size));
     }
 
     @Operation(summary = "쿠폰 조회 API(최신순)")

--- a/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
@@ -58,13 +58,22 @@ public class CouponController {
     }
 
     @Operation(summary = "쿠폰 조회 API(추천순, 거리순, 최근순)")
+    @Parameters(value = {
+            @Parameter(name = "type", description = "조회 타입 지정(추천순: RECOMMEND, 거리순: DISTANCE, 최근순: RECENT"),
+            @Parameter(name = "latitude", description = "유저의 현재 위치의 위도(최근순의 경우 사용 X)"),
+            @Parameter(name = "longitude", description = "유저의 현재 위치의 경도(최근순의 경우 사용 X)"),
+            @Parameter(name = "page", description = "페이지 번호(0부터 시작)"),
+            @Parameter(name = "size", description = "한 페이지 당 이벤트 개수"),
+    })
     @GetMapping("/recommend")
     public BaseResponse<CouponPagingResponse<CouponSummaryInquiryResponse>> inquiryCoupon(
             @RequestParam(name = "type") InquiryType type,
+            @RequestParam(name = "latitude") Double latitude,
+            @RequestParam(name = "longitude") Double longitude,
             @RequestParam(name = "page") int page,
             @RequestParam(name = "size") int size
     ){
-        return BaseResponse.onSuccess(couponService.inquiryCoupon(type, page , size));
+        return BaseResponse.onSuccess(couponService.inquiryCoupon(type, latitude, longitude, page , size));
     }
 
     @Operation(summary = "쿠폰 상세 조회 API")

--- a/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/connectCo/domain/coupon/controller/CouponController.java
@@ -3,12 +3,15 @@ package com.connectCo.domain.coupon.controller;
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.coupon.dto.response.CouponDetailResponse;
 import com.connectCo.domain.coupon.dto.response.CouponIdResponse;
+import com.connectCo.domain.coupon.dto.response.CouponPagingResponse;
 import com.connectCo.domain.coupon.dto.response.CouponSummaryInquiryResponse;
 import com.connectCo.domain.coupon.service.CouponService;
 import com.connectCo.domain.store.entity.Store;
 import com.connectCo.domain.store.service.StoreService;
 import com.connectCo.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +32,15 @@ public class CouponController {
 
     @Operation(summary = "나의 쿠폰 조회 API")
     @GetMapping("/mine")
-    public BaseResponse<List<CouponSummaryInquiryResponse>> inquiryCouponByMember() {
-        return BaseResponse.onSuccess(couponService.inquiryCouponByMember());
+    @Parameters(value = {
+            @Parameter(name = "page", description = "페이지 번호(0부터 시작)"),
+            @Parameter(name = "size", description = "한 페이지 당 쿠폰 개수"),
+    })
+    public BaseResponse<CouponPagingResponse<CouponSummaryInquiryResponse>> inquiryCouponByMember(
+            @RequestParam(name = "page") int page,
+            @RequestParam(name = "size") int size
+    ) {
+        return BaseResponse.onSuccess(couponService.inquiryCouponByMember(page, size));
     }
 
     @Operation(summary = "내가 찜한 쿠폰 조회 API")

--- a/src/main/java/com/connectCo/domain/coupon/dto/response/CouponDetailResponse.java
+++ b/src/main/java/com/connectCo/domain/coupon/dto/response/CouponDetailResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -13,15 +14,12 @@ public class CouponDetailResponse {
 
     private Long id;
     private Long storeId;
+    private String storeName;
     private String name;
     private String description;
     private String priorityTarget;
     private String notification;
-    private String couponType;
     private LocalDate expiredAt;
+    private LocalDateTime createdAt;
     private List<String> images;
-    private int validCount;
-    private int validPeriod;
-    private LocalDate validDate;
-
 }

--- a/src/main/java/com/connectCo/domain/coupon/dto/response/CouponPagingResponse.java
+++ b/src/main/java/com/connectCo/domain/coupon/dto/response/CouponPagingResponse.java
@@ -1,0 +1,17 @@
+package com.connectCo.domain.coupon.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CouponPagingResponse<T> {
+    private List<T> coupons;
+    private int page;
+    private int totalPages;
+    private int totalElements;
+    private Boolean isFirst;
+    private Boolean isLast;
+}

--- a/src/main/java/com/connectCo/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/connectCo/domain/coupon/entity/Coupon.java
@@ -42,9 +42,11 @@ public class Coupon extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private CouponType couponType;
-    //
+
     private int validCount;
+
     private int validPeriod;
+
     private LocalDate validDate;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/connectCo/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/connectCo/domain/coupon/entity/Coupon.java
@@ -1,6 +1,7 @@
 package com.connectCo.domain.coupon.entity;
 
 
+import com.connectCo.domain.address.entity.Address;
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.sponsorship.entity.Sponsorship;
 import com.connectCo.domain.store.entity.Store;
@@ -48,6 +49,10 @@ public class Coupon extends BaseEntity {
     private int validPeriod;
 
     private LocalDate validDate;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn
+    private Address address;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn

--- a/src/main/java/com/connectCo/domain/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/connectCo/domain/coupon/mapper/CouponMapper.java
@@ -2,10 +2,13 @@ package com.connectCo.domain.coupon.mapper;
 
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.coupon.dto.response.CouponDetailResponse;
+import com.connectCo.domain.coupon.dto.response.CouponPagingResponse;
 import com.connectCo.domain.coupon.dto.response.CouponSummaryInquiryResponse;
 import com.connectCo.domain.coupon.entity.Coupon;
 import com.connectCo.domain.coupon.entity.CouponImage;
 import com.connectCo.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.scheduling.config.Task;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -59,16 +62,23 @@ public class CouponMapper {
         return CouponDetailResponse.builder()
                 .id(coupon.getId())
                 .storeId(coupon.getStore().getId())
+                .storeName(coupon.getStore().getName())
                 .name(coupon.getName())
                 .description(coupon.getDescription())
                 .priorityTarget(coupon.getPriorityTarget())
                 .notification(coupon.getNotification())
-                .couponType(coupon.getCouponType().toString())
                 .expiredAt(coupon.getExpiredAt())
                 .images(imageUrls)
-                .validCount(coupon.getValidCount())
-                .validPeriod(coupon.getValidPeriod())
-                .validDate(coupon.getValidDate())
+                .build();
+    }
+
+    public <T> CouponPagingResponse<T> toCouponPagingResponse(Page<T> coupons){
+        return CouponPagingResponse.<T>builder()
+                .coupons(coupons.getContent())
+                .totalPages(coupons.getTotalPages())
+                .totalElements((int) coupons.getTotalElements())
+                .isFirst(coupons.isFirst())
+                .isLast(coupons.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/connectCo/domain/coupon/repository/CouponLikeRepository.java
+++ b/src/main/java/com/connectCo/domain/coupon/repository/CouponLikeRepository.java
@@ -2,10 +2,17 @@ package com.connectCo.domain.coupon.repository;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.coupon.entity.CouponLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CouponLikeRepository extends JpaRepository<CouponLike, Long> {
-    List<CouponLike> findAllByMemberAndIsChecked(Member member, boolean isChecked);
+    //List<CouponLike> findAllByMemberAndIsChecked(Member member, boolean isChecked);
+
+    @Query("SELECT cl.coupon FROM CouponLike cl WHERE cl.member = :member AND cl.isChecked = :isChecked")
+    Page<CouponLike> findAllByMemberAndIsChecked(@Param("member") Member member, @Param("isChecked") boolean isChecked, Pageable pageable);
 }

--- a/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
@@ -5,12 +5,16 @@ import com.connectCo.domain.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
-    List<Coupon> findAllByStore(Store store);
+    @Query("SELECT c FROM Coupon c WHERE c.store IN :stores AND c.expiredAt >= :currentDate ORDER BY c.createdAt DESC ")
+    Page<Coupon> findAllByStores(@Param("stores") List<Store> stores, @Param("currentDate") LocalDate currentDate, Pageable pageable);
 
     Page<Coupon> findAllByOrderByCreatedAtDesc(Pageable pageable);
 

--- a/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
@@ -13,10 +13,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
-    
+
     //마이페이지 가게별 내 쿠폰 조회
     @Query("SELECT c FROM Coupon c WHERE c.store IN :stores AND c.expiredAt >= :currentDate ORDER BY c.createdAt DESC ")
     Page<Coupon> findAllByStores(@Param("stores") List<Store> stores, @Param("currentDate") LocalDate currentDate, Pageable pageable);
+
     // 추천순으로 쿠폰 조회
     @Query("SELECT c FROM Coupon c JOIN c.store.address a WHERE c.expiredAt >= :currentDate " +
             "ORDER BY function('ST_Distance_Sphere', point(a.longitude, a.latitude), point(:longitude, :latitude)) ASC")
@@ -24,7 +25,12 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
                                     @Param("longitude") double longitude,
                                     @Param("currentDate") LocalDate currentDate,
                                     Pageable pageable);
+
     @Query("SELECT c FROM Coupon c WHERE c.expiredAt >= :currentDate  ORDER BY c.createdAt DESC")
     Page<Coupon> findAllByCreatedAt(@Param("currentDate") LocalDate currentDate, Pageable pageable);
 
+    @Query("SELECT c FROM Coupon c JOIN c.address a WHERE c.expiredAt >= :currentDate " +
+            "ORDER BY function('ST_Distance_Sphere', point(a.longitude, a.latitude), point(:longitude, :latitude)) ASC")
+    Page<Coupon> findAllByDistance(@Param("latitude") double latitude, @Param("longitude") double longitude,
+                                   @Param("currentDate") LocalDate currentDate, Pageable pageable);
 }

--- a/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
@@ -24,7 +24,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
                                     @Param("longitude") double longitude,
                                     @Param("currentDate") LocalDate currentDate,
                                     Pageable pageable);
-    //쿠폰 최신순 조회
-    Page<Coupon> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("SELECT c FROM Coupon c WHERE c.expiredAt >= :currentDate  ORDER BY c.createdAt DESC")
+    Page<Coupon> findAllByCreatedAt(@Param("currentDate") LocalDate currentDate, Pageable pageable);
 
 }

--- a/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/connectCo/domain/coupon/repository/CouponRepository.java
@@ -1,6 +1,7 @@
 package com.connectCo.domain.coupon.repository;
 
 import com.connectCo.domain.coupon.entity.Coupon;
+import com.connectCo.domain.event.entity.Event;
 import com.connectCo.domain.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,10 +13,18 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
-
+    
+    //마이페이지 가게별 내 쿠폰 조회
     @Query("SELECT c FROM Coupon c WHERE c.store IN :stores AND c.expiredAt >= :currentDate ORDER BY c.createdAt DESC ")
     Page<Coupon> findAllByStores(@Param("stores") List<Store> stores, @Param("currentDate") LocalDate currentDate, Pageable pageable);
-
+    // 추천순으로 쿠폰 조회
+    @Query("SELECT c FROM Coupon c JOIN c.store.address a WHERE c.expiredAt >= :currentDate " +
+            "ORDER BY function('ST_Distance_Sphere', point(a.longitude, a.latitude), point(:longitude, :latitude)) ASC")
+    Page<Coupon> findAllByRecommend(@Param("latitude") double latitude,
+                                    @Param("longitude") double longitude,
+                                    @Param("currentDate") LocalDate currentDate,
+                                    Pageable pageable);
+    //쿠폰 최신순 조회
     Page<Coupon> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
 }

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public interface CouponService {
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size);
-    List<CouponSummaryInquiryResponse> inquiryCouponByLike();
+    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size);
     List<CouponSummaryInquiryResponse> inquiryCouponByRecent();
     List<CouponSummaryInquiryResponse> inquiryCouponByEachStore(Long storeId);
 

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
@@ -3,6 +3,7 @@ package com.connectCo.domain.coupon.service;
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.coupon.dto.response.CouponDetailResponse;
 import com.connectCo.domain.coupon.dto.response.CouponIdResponse;
+import com.connectCo.domain.coupon.dto.response.CouponPagingResponse;
 import com.connectCo.domain.coupon.dto.response.CouponSummaryInquiryResponse;
 import com.connectCo.domain.coupon.entity.Coupon;
 import com.connectCo.domain.store.entity.Store;
@@ -12,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface CouponService {
-    List<CouponSummaryInquiryResponse> inquiryCouponByMember();
+    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size);
     List<CouponSummaryInquiryResponse> inquiryCouponByLike();
     List<CouponSummaryInquiryResponse> inquiryCouponByRecent();
     List<CouponSummaryInquiryResponse> inquiryCouponByEachStore(Long storeId);
@@ -27,8 +28,4 @@ public interface CouponService {
     CouponIdResponse deleteCoupon(Long couponId);
 
     CouponIdResponse updateCoupon(Long couponId, @Nullable List<MultipartFile> couponImages, CouponCreateRequest request);
-
-
-
-
 }

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
@@ -7,6 +7,7 @@ import com.connectCo.domain.coupon.dto.response.CouponPagingResponse;
 import com.connectCo.domain.coupon.dto.response.CouponSummaryInquiryResponse;
 import com.connectCo.domain.coupon.entity.Coupon;
 import com.connectCo.domain.store.entity.Store;
+import com.connectCo.global.common.enums.InquiryType;
 import jakarta.annotation.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,16 +16,12 @@ import java.util.List;
 public interface CouponService {
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size);
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size);
-    List<CouponSummaryInquiryResponse> inquiryCouponByRecent();
-    List<CouponSummaryInquiryResponse> inquiryCouponByEachStore(Long storeId);
-
-    List<Coupon> inquiryCouponByStore(Store store);
-
+    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecent();
+    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, int page, int size);
     CouponDetailResponse inquiryCouponDetail(Long couponId);
 
     CouponIdResponse createCoupon(List<MultipartFile> couponImages, CouponCreateRequest request);
-
-
+    
     CouponIdResponse deleteCoupon(Long couponId);
 
     CouponIdResponse updateCoupon(Long couponId, @Nullable List<MultipartFile> couponImages, CouponCreateRequest request);

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
@@ -14,14 +14,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface CouponService {
+    CouponIdResponse createCoupon(List<MultipartFile> couponImages, CouponCreateRequest request);
+    CouponIdResponse deleteCoupon(Long couponId);
+    CouponIdResponse updateCoupon(Long couponId, @Nullable List<MultipartFile> couponImages, CouponCreateRequest request);
+
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size);
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size);
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, double latitude, double longitude, int page, int size);
     CouponDetailResponse inquiryCouponDetail(Long couponId);
-
-    CouponIdResponse createCoupon(List<MultipartFile> couponImages, CouponCreateRequest request);
-
-    CouponIdResponse deleteCoupon(Long couponId);
-
-    CouponIdResponse updateCoupon(Long couponId, @Nullable List<MultipartFile> couponImages, CouponCreateRequest request);
 }

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
@@ -16,12 +16,11 @@ import java.util.List;
 public interface CouponService {
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size);
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size);
-    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecent();
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, int page, int size);
     CouponDetailResponse inquiryCouponDetail(Long couponId);
 
     CouponIdResponse createCoupon(List<MultipartFile> couponImages, CouponCreateRequest request);
-    
+
     CouponIdResponse deleteCoupon(Long couponId);
 
     CouponIdResponse updateCoupon(Long couponId, @Nullable List<MultipartFile> couponImages, CouponCreateRequest request);

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponService.java
@@ -16,7 +16,7 @@ import java.util.List;
 public interface CouponService {
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size);
     CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size);
-    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, int page, int size);
+    CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, double latitude, double longitude, int page, int size);
     CouponDetailResponse inquiryCouponDetail(Long couponId);
 
     CouponIdResponse createCoupon(List<MultipartFile> couponImages, CouponCreateRequest request);

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -66,11 +66,15 @@ public class CouponServiceImpl implements CouponService {
         Member member = authService.getLoginMember();
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<CouponSummaryInquiryResponse> coupons = couponLikeRepository.findAllByMemberAndIsChecked(member, true, pageable)
-                .map(CouponLike::getCoupon)
-                .map(couponMapper::toCouponSummaryInquiryResponse);
+        Page<CouponSummaryInquiryResponse> coupons = findLikedCouponsByMember(member, pageable);
 
         return couponMapper.toCouponPagingResponse(coupons);
+    }
+
+    private Page<CouponSummaryInquiryResponse> findLikedCouponsByMember(Member member, Pageable pageable) {
+        return couponLikeRepository.findAllByMemberAndIsChecked(member, true, pageable)
+                .map(CouponLike::getCoupon)
+                .map(couponMapper::toCouponSummaryInquiryResponse);
     }
 
     /*

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -57,16 +57,15 @@ public class CouponServiceImpl implements CouponService {
     }
 
     @Override
-    public List<CouponSummaryInquiryResponse> inquiryCouponByLike() {
+    public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size) {
         Member member = authService.getLoginMember();
+        Pageable pageable = PageRequest.of(page, size);
 
-        List<Coupon> couponList = couponLikeRepository.findAllByMemberAndIsChecked(member, true).stream()
+        Page<CouponSummaryInquiryResponse> coupons = couponLikeRepository.findAllByMemberAndIsChecked(member, true, pageable)
                 .map(CouponLike::getCoupon)
-                .toList();
+                .map(couponMapper::toCouponSummaryInquiryResponse);
 
-        return couponList.stream()
-                .map(couponMapper::toCouponSummaryInquiryResponse)
-                .toList();
+        return couponMapper.toCouponPagingResponse(coupons);
     }
 
     @Override

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -2,6 +2,7 @@ package com.connectCo.domain.coupon.service;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.Member.service.AuthService;
+import com.connectCo.domain.address.entity.Address;
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.coupon.dto.response.CouponDetailResponse;
 import com.connectCo.domain.coupon.dto.response.CouponIdResponse;
@@ -14,10 +15,17 @@ import com.connectCo.domain.coupon.mapper.CouponMapper;
 import com.connectCo.domain.coupon.repository.CouponImageRepository;
 import com.connectCo.domain.coupon.repository.CouponLikeRepository;
 import com.connectCo.domain.coupon.repository.CouponRepository;
+import com.connectCo.domain.event.dto.response.EventPagingResponse;
+import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
+import com.connectCo.domain.event.entity.Event;
+import com.connectCo.domain.organization.entity.Organization;
+import com.connectCo.domain.organization.repository.OrganizationRepository;
 import com.connectCo.domain.store.entity.Store;
 import com.connectCo.domain.store.service.StoreService;
+import com.connectCo.global.common.enums.InquiryType;
 import com.connectCo.global.exception.CustomApiException;
 import com.connectCo.global.exception.ErrorCode;
+import com.connectCo.global.validation.ParamValidator;
 import com.connectCo.utils.S3FileComponent;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +50,7 @@ public class CouponServiceImpl implements CouponService {
     private final CouponMapper couponMapper;
     private final S3FileComponent s3FileComponent;
     private final CouponImageRepository couponImageRepository;
+    private final OrganizationRepository organizationRepository;
 
     @Override
     public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size) {
@@ -66,16 +75,6 @@ public class CouponServiceImpl implements CouponService {
                 .map(couponMapper::toCouponSummaryInquiryResponse);
 
         return couponMapper.toCouponPagingResponse(coupons);
-    }
-
-    @Override
-    public List<CouponSummaryInquiryResponse> inquiryCouponByRecent() {
-        Pageable pageable= PageRequest.of(0,10);
-        List<Coupon> couponList=couponRepository.findAllByOrderByCreatedAtDesc(pageable).getContent();
-
-        return couponList.stream()
-                .map(couponMapper::toCouponSummaryInquiryResponse)
-                .toList();
     }
 
     /*
@@ -169,18 +168,6 @@ public class CouponServiceImpl implements CouponService {
     }
 
     @Override
-    public List<CouponSummaryInquiryResponse> inquiryCouponByEachStore(Long storeId) {
-        Store store=storeService.loadStore(storeId);
-        return inquiryCouponByStore(store).stream()
-                .map(couponMapper::toCouponSummaryInquiryResponse)
-                .toList();
-    }
-    public List<Coupon> inquiryCouponByStore(Store store) {
-        return couponRepository.findAllByStore(store);
-    }
-
-
-    @Override
     @Transactional(readOnly = true)
     public CouponDetailResponse inquiryCouponDetail(Long couponId) {
         Coupon coupon = couponRepository.findById(couponId)
@@ -189,4 +176,37 @@ public class CouponServiceImpl implements CouponService {
         return couponMapper.toCouponDetailResponse(coupon);
     }
 
+    @Override
+    public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, int page, int size){
+        Pageable pageable = PageRequest.of(page, size);
+
+        return switch (type) {
+            case RECOMMEND -> inquiryCouponByRecommend(pageable);
+            case RECENT -> null;
+            case DISTANCE -> null;
+            default -> throw new CustomApiException(ErrorCode.UNKNOWN_INQUIRY_TYPE);
+        };
+    }
+
+    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecommend(Pageable pageable){
+        Member member = authService.getLoginMember();
+        Organization organization = getMemberOrganization(member);
+        Address address = organization.getAddress();
+
+        Page<Coupon> couponPage = findRecommendedCoupons(address, pageable);
+
+        return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
+    }
+
+    private Page<Coupon> findRecommendedCoupons(Address address, Pageable pageable) {
+        LocalDate currentDate = LocalDate.now();
+        double latitude = address.getLatitude();
+        double longitude = address.getLongitude();
+        return couponRepository.findAllByRecommend(latitude, longitude, currentDate, pageable);
+    }
+
+    private Organization getMemberOrganization(Member member) {
+        return organizationRepository.findOrganizationByMember(member)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.ORGANIZATION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -44,6 +44,10 @@ public class CouponServiceImpl implements CouponService {
     private final S3FileComponent s3FileComponent;
     private final CouponImageRepository couponImageRepository;
 
+
+    /*
+     * 내 쿠폰 조회
+     */
     @Override
     public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size) {
         Member member = authService.getLoginMember();
@@ -61,6 +65,9 @@ public class CouponServiceImpl implements CouponService {
                 .map(couponMapper::toCouponSummaryInquiryResponse);
     }
 
+    /*
+     * 찜한 쿠폰을 조회
+     */
     @Override
     public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByLike(int page, int size) {
         Member member = authService.getLoginMember();
@@ -115,7 +122,6 @@ public class CouponServiceImpl implements CouponService {
                 .toList();
     }
 
-
     @Override
     @Transactional
     public CouponIdResponse deleteCoupon(Long couponId) {
@@ -130,8 +136,6 @@ public class CouponServiceImpl implements CouponService {
         couponRepository.deleteById(deletedCouponId);
         return new CouponIdResponse(deletedCouponId);
     }
-
-
 
     @Override
     @Transactional
@@ -167,6 +171,9 @@ public class CouponServiceImpl implements CouponService {
         return new CouponIdResponse(coupon.getId());
     }
 
+    /*
+     * 쿠폰 상세보기
+     */
     @Override
     @Transactional(readOnly = true)
     public CouponDetailResponse inquiryCouponDetail(Long couponId) {
@@ -192,16 +199,25 @@ public class CouponServiceImpl implements CouponService {
         };
     }
 
+    /*
+     * 추천 쿠폰 조회 함수
+     */
     private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecommend(double latitude, double longitude, LocalDate currentDate, Pageable pageable){
         Page<Coupon> couponPage = couponRepository.findAllByRecommend(latitude, longitude, currentDate, pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
 
+    /*
+     * 최신순 쿠폰 조회 함수
+     */
     private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByCreatedAt(LocalDate currentDate, Pageable pageable){
         Page<Coupon> couponPage = couponRepository.findAllByCreatedAt(currentDate, pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
 
+    /*
+     * 거리순 쿠폰 조회 함수
+     */
     private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByDistance(double latitude, double longitude, LocalDate currentDate, Pageable pageable){
         Page<Coupon> couponPage = couponRepository.findAllByDistance(latitude, longitude,currentDate, pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -5,6 +5,7 @@ import com.connectCo.domain.Member.service.AuthService;
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.coupon.dto.response.CouponDetailResponse;
 import com.connectCo.domain.coupon.dto.response.CouponIdResponse;
+import com.connectCo.domain.coupon.dto.response.CouponPagingResponse;
 import com.connectCo.domain.coupon.dto.response.CouponSummaryInquiryResponse;
 import com.connectCo.domain.coupon.entity.Coupon;
 import com.connectCo.domain.coupon.entity.CouponImage;
@@ -20,12 +21,14 @@ import com.connectCo.global.exception.ErrorCode;
 import com.connectCo.utils.S3FileComponent;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -41,16 +44,16 @@ public class CouponServiceImpl implements CouponService {
     private final CouponImageRepository couponImageRepository;
 
     @Override
-    public List<CouponSummaryInquiryResponse> inquiryCouponByMember() {
+    public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size) {
         Member member = authService.getLoginMember();
+        LocalDate currentDate = LocalDate.now();
+        Pageable pageable = PageRequest.of(page, size);
 
-        List<Coupon> couponList = storeService.getStoresByMember(member).stream()
-                .flatMap(store -> couponRepository.findAllByStore(store).stream())
-                .toList();
+        List<Store> stores = storeService.getStoresByMember(member);
+        Page<CouponSummaryInquiryResponse> coupons = couponRepository.findAllByStores(stores, currentDate, pageable)
+                .map(couponMapper::toCouponSummaryInquiryResponse);
 
-        return couponList.stream()
-                .map(couponMapper::toCouponSummaryInquiryResponse)
-                .toList();
+        return couponMapper.toCouponPagingResponse(coupons);
     }
 
     @Override

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -15,17 +15,13 @@ import com.connectCo.domain.coupon.mapper.CouponMapper;
 import com.connectCo.domain.coupon.repository.CouponImageRepository;
 import com.connectCo.domain.coupon.repository.CouponLikeRepository;
 import com.connectCo.domain.coupon.repository.CouponRepository;
-import com.connectCo.domain.event.dto.response.EventPagingResponse;
-import com.connectCo.domain.event.dto.response.EventSummaryInquiryResponse;
-import com.connectCo.domain.event.entity.Event;
 import com.connectCo.domain.organization.entity.Organization;
-import com.connectCo.domain.organization.repository.OrganizationRepository;
+import com.connectCo.domain.organization.service.OrganizationService;
 import com.connectCo.domain.store.entity.Store;
 import com.connectCo.domain.store.service.StoreService;
 import com.connectCo.global.common.enums.InquiryType;
 import com.connectCo.global.exception.CustomApiException;
 import com.connectCo.global.exception.ErrorCode;
-import com.connectCo.global.validation.ParamValidator;
 import com.connectCo.utils.S3FileComponent;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +46,7 @@ public class CouponServiceImpl implements CouponService {
     private final CouponMapper couponMapper;
     private final S3FileComponent s3FileComponent;
     private final CouponImageRepository couponImageRepository;
-    private final OrganizationRepository organizationRepository;
+    private final OrganizationService organizationService;
 
     @Override
     public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size) {
@@ -182,7 +178,7 @@ public class CouponServiceImpl implements CouponService {
 
         return switch (type) {
             case RECOMMEND -> inquiryCouponByRecommend(pageable);
-            case RECENT -> null;
+            case RECENT -> inquiryCouponByRecent(pageable);
             case DISTANCE -> null;
             default -> throw new CustomApiException(ErrorCode.UNKNOWN_INQUIRY_TYPE);
         };
@@ -190,11 +186,16 @@ public class CouponServiceImpl implements CouponService {
 
     private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecommend(Pageable pageable){
         Member member = authService.getLoginMember();
-        Organization organization = getMemberOrganization(member);
+        Organization organization = organizationService.loadOrganizationByMember(member);
         Address address = organization.getAddress();
 
         Page<Coupon> couponPage = findRecommendedCoupons(address, pageable);
 
+        return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
+    }
+
+    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecent(Pageable pageable){
+        Page<Coupon> couponPage = findRecentlyCreatedCoupons(pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
 
@@ -205,8 +206,9 @@ public class CouponServiceImpl implements CouponService {
         return couponRepository.findAllByRecommend(latitude, longitude, currentDate, pageable);
     }
 
-    private Organization getMemberOrganization(Member member) {
-        return organizationRepository.findOrganizationByMember(member)
-                .orElseThrow(() -> new CustomApiException(ErrorCode.ORGANIZATION_NOT_FOUND));
+    private Page<Coupon> findRecentlyCreatedCoupons(Pageable pageable) {
+        LocalDate currentDate = LocalDate.now();
+        return couponRepository.findAllByCreatedAt(currentDate, pageable);
     }
+
 }

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -173,42 +173,30 @@ public class CouponServiceImpl implements CouponService {
     }
 
     @Override
-    public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, int page, int size){
+    public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, double latitude, double longitude, int page, int size){
+        LocalDate currentDate = LocalDate.now();
         Pageable pageable = PageRequest.of(page, size);
 
         return switch (type) {
-            case RECOMMEND -> inquiryCouponByRecommend(pageable);
-            case RECENT -> inquiryCouponByRecent(pageable);
-            case DISTANCE -> null;
+            case RECOMMEND -> inquiryCouponByRecommend(latitude, longitude, currentDate, pageable);
+            case RECENT -> inquiryCouponByRecent(currentDate, pageable);
+            case DISTANCE -> inquiryCouponByDistance(latitude, longitude, currentDate, pageable);
             default -> throw new CustomApiException(ErrorCode.UNKNOWN_INQUIRY_TYPE);
         };
     }
 
-    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecommend(Pageable pageable){
-        Member member = authService.getLoginMember();
-        Organization organization = organizationService.loadOrganizationByMember(member);
-        Address address = organization.getAddress();
-
-        Page<Coupon> couponPage = findRecommendedCoupons(address, pageable);
-
+    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecommend(double latitude, double longitude, LocalDate currentDate, Pageable pageable){
+        Page<Coupon> couponPage = couponRepository.findAllByRecommend(latitude, longitude, currentDate, pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
 
-    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecent(Pageable pageable){
-        Page<Coupon> couponPage = findRecentlyCreatedCoupons(pageable);
+    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecent(LocalDate currentDate, Pageable pageable){
+        Page<Coupon> couponPage = couponRepository.findAllByCreatedAt(currentDate, pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
 
-    private Page<Coupon> findRecommendedCoupons(Address address, Pageable pageable) {
-        LocalDate currentDate = LocalDate.now();
-        double latitude = address.getLatitude();
-        double longitude = address.getLongitude();
-        return couponRepository.findAllByRecommend(latitude, longitude, currentDate, pageable);
+    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByDistance(double latitude, double longitude, LocalDate currentDate, Pageable pageable){
+        Page<Coupon> couponPage = couponRepository.findAllByDistance(latitude, longitude,currentDate, pageable);
+        return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
-
-    private Page<Coupon> findRecentlyCreatedCoupons(Pageable pageable) {
-        LocalDate currentDate = LocalDate.now();
-        return couponRepository.findAllByCreatedAt(currentDate, pageable);
-    }
-
 }

--- a/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/coupon/service/CouponServiceImpl.java
@@ -2,7 +2,6 @@ package com.connectCo.domain.coupon.service;
 
 import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.Member.service.AuthService;
-import com.connectCo.domain.address.entity.Address;
 import com.connectCo.domain.coupon.dto.request.CouponCreateRequest;
 import com.connectCo.domain.coupon.dto.response.CouponDetailResponse;
 import com.connectCo.domain.coupon.dto.response.CouponIdResponse;
@@ -15,8 +14,6 @@ import com.connectCo.domain.coupon.mapper.CouponMapper;
 import com.connectCo.domain.coupon.repository.CouponImageRepository;
 import com.connectCo.domain.coupon.repository.CouponLikeRepository;
 import com.connectCo.domain.coupon.repository.CouponRepository;
-import com.connectCo.domain.organization.entity.Organization;
-import com.connectCo.domain.organization.service.OrganizationService;
 import com.connectCo.domain.store.entity.Store;
 import com.connectCo.domain.store.service.StoreService;
 import com.connectCo.global.common.enums.InquiryType;
@@ -46,7 +43,6 @@ public class CouponServiceImpl implements CouponService {
     private final CouponMapper couponMapper;
     private final S3FileComponent s3FileComponent;
     private final CouponImageRepository couponImageRepository;
-    private final OrganizationService organizationService;
 
     @Override
     public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByMember(int page, int size) {
@@ -54,11 +50,15 @@ public class CouponServiceImpl implements CouponService {
         LocalDate currentDate = LocalDate.now();
         Pageable pageable = PageRequest.of(page, size);
 
-        List<Store> stores = storeService.getStoresByMember(member);
-        Page<CouponSummaryInquiryResponse> coupons = couponRepository.findAllByStores(stores, currentDate, pageable)
-                .map(couponMapper::toCouponSummaryInquiryResponse);
+        Page<CouponSummaryInquiryResponse> coupons = findCouponsByMember(member, currentDate, pageable);
 
         return couponMapper.toCouponPagingResponse(coupons);
+    }
+
+    private Page<CouponSummaryInquiryResponse> findCouponsByMember(Member member, LocalDate currentDate, Pageable pageable) {
+        List<Store> stores = storeService.getStoresByMember(member);
+        return couponRepository.findAllByStores(stores, currentDate, pageable)
+                .map(couponMapper::toCouponSummaryInquiryResponse);
     }
 
     @Override
@@ -172,6 +172,9 @@ public class CouponServiceImpl implements CouponService {
         return couponMapper.toCouponDetailResponse(coupon);
     }
 
+    /*
+     * 조건에 따른 쿠폰 조회
+     */
     @Override
     public CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCoupon(InquiryType type, double latitude, double longitude, int page, int size){
         LocalDate currentDate = LocalDate.now();
@@ -179,7 +182,7 @@ public class CouponServiceImpl implements CouponService {
 
         return switch (type) {
             case RECOMMEND -> inquiryCouponByRecommend(latitude, longitude, currentDate, pageable);
-            case RECENT -> inquiryCouponByRecent(currentDate, pageable);
+            case RECENT -> inquiryCouponByCreatedAt(currentDate, pageable);
             case DISTANCE -> inquiryCouponByDistance(latitude, longitude, currentDate, pageable);
             default -> throw new CustomApiException(ErrorCode.UNKNOWN_INQUIRY_TYPE);
         };
@@ -190,7 +193,7 @@ public class CouponServiceImpl implements CouponService {
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }
 
-    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByRecent(LocalDate currentDate, Pageable pageable){
+    private CouponPagingResponse<CouponSummaryInquiryResponse> inquiryCouponByCreatedAt(LocalDate currentDate, Pageable pageable){
         Page<Coupon> couponPage = couponRepository.findAllByCreatedAt(currentDate, pageable);
         return couponMapper.toCouponPagingResponse(couponPage.map(couponMapper::toCouponSummaryInquiryResponse));
     }

--- a/src/main/java/com/connectCo/domain/event/controller/EventController.java
+++ b/src/main/java/com/connectCo/domain/event/controller/EventController.java
@@ -4,7 +4,6 @@ import com.connectCo.domain.event.dto.request.EventCreateRequest;
 import com.connectCo.domain.event.dto.request.EventUpdateRequest;
 import com.connectCo.domain.event.dto.response.*;
 import com.connectCo.domain.event.service.EventService;
-import com.connectCo.domain.store.dto.response.StoreLocationInquiryResponse;
 import com.connectCo.global.common.BaseResponse;
 import com.connectCo.global.common.enums.InquiryType;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/connectCo/domain/organization/entity/Organization.java
+++ b/src/main/java/com/connectCo/domain/organization/entity/Organization.java
@@ -1,5 +1,6 @@
 package com.connectCo.domain.organization.entity;
 
+import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.address.entity.Address;
 import com.connectCo.domain.organization.dto.request.OrganizationUpdateRequest;
 import com.connectCo.global.common.BaseEntity;
@@ -32,6 +33,9 @@ public class Organization extends BaseEntity {
     @Column(nullable = false)
     private String academicDayUrl;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Member member;
 
     public void updateOrganizationInfo(OrganizationUpdateRequest request) {
         this.name = request.getName();

--- a/src/main/java/com/connectCo/domain/organization/repository/OrganizationRepository.java
+++ b/src/main/java/com/connectCo/domain/organization/repository/OrganizationRepository.java
@@ -1,5 +1,6 @@
 package com.connectCo.domain.organization.repository;
 
+import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.organization.entity.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,6 +11,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
     // 키워드로 조직을 검색
     List<Organization> findAllByNameContainingIgnoreCaseOrderByNameAsc(String keyword);
     Optional<Organization> findOrganizationByName(String name);
+    Optional<Organization> findOrganizationByMember(Member member);
 
     boolean existsOrganizationByName(String name);
 }

--- a/src/main/java/com/connectCo/domain/organization/service/OrganizationService.java
+++ b/src/main/java/com/connectCo/domain/organization/service/OrganizationService.java
@@ -1,5 +1,6 @@
 package com.connectCo.domain.organization.service;
 
+import com.connectCo.domain.Member.entity.Member;
 import com.connectCo.domain.organization.dto.request.OrganizationCreateRequest;
 import com.connectCo.domain.organization.dto.request.OrganizationUpdateRequest;
 import com.connectCo.domain.organization.dto.response.OrganizationIdResponse;
@@ -19,4 +20,5 @@ public interface OrganizationService {
     List<OrganizationSearchResponse> searchOrganization(String keyword);
     Organization loadOrganization(Long organizationId);
     Organization loadOrganizationByName(String name);
+    Organization loadOrganizationByMember(Member member);
 }

--- a/src/main/java/com/connectCo/domain/organization/service/OrganizationServiceImpl.java
+++ b/src/main/java/com/connectCo/domain/organization/service/OrganizationServiceImpl.java
@@ -110,6 +110,12 @@ public class OrganizationServiceImpl implements OrganizationService {
                 .orElseThrow(() -> new CustomApiException(ErrorCode.ORGANIZATION_NOT_FOUND));
     }
 
+    @Override
+    public Organization loadOrganizationByMember(Member member) {
+        return organizationRepository.findOrganizationByMember(member)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.ORGANIZATION_NOT_FOUND));
+    }
+
 
     private void validateAdmin() {
         Member member = authService.getLoginMember();


### PR DESCRIPTION
## 추가/수정한 기능 설명
쿠폰 전체 API 리팩토링

쿠폰 API 목록
1. 쿠폰 생성, 삭제, 수정
2. 쿠폰 상세 조회
3. 내 쿠폰 조회
4. 찜한 쿠폰 조회
5. 조건에 따른 쿠폰 조회(추천순, 최신순, 거리순)
- 이벤트 서비스와 코드 구조 통일
- 추천순 : 요구사항에 맞게 사용자 근처 쿠폰만 조회되게 로직 추가
- 최신순 : 생성순으로 쿠폰 조회
- 거리순 : 사용자 위치에 따라 거리순으로 쿠폰 조회

조회 API 페이징 구현 (List->Page 로 수정)

<br>

Q. 
쿠폰 생성의 경우 쿠폰 타입에 따라 사용 횟수 제한, 사용 기간 제한, 사용 날짜 제한으로 나뉘게 되는데 
경험상 쿠폰은 정해진 개수만큼(요구된 개수만큼) 발행되고 사용 기간에 제한이 있는 형식이 보통이라 의논 후 수정이 필요할거 같음. 

## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
